### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ When AI tools can read your product documentation, they become **significantly**
 Can you check in biel_ai what the auth headers are for the /users endpoint?
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/techdocsstudio-biel-mcp).
+
 ## Self-hosting (Optional)
 
 For advanced users who prefer to run their own MCP server instance:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/techdocsstudio-biel-mcp).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about a hosted deployment option, providing users with an alternative to self-hosting for easier setup and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->