### PR TITLE
fix: auto-recreate expired MCP sessions on streamable HTTP endpoint

### DIFF
--- a/biel_mcp_server.py
+++ b/biel_mcp_server.py
@@ -616,16 +616,20 @@ async def streamable_http_endpoint_v2(
                     status_code=400
                 )
             
-            # Validate session
+            # Validate session - auto-recreate if expired
             session = session_manager.get_session(mcp_session_id)
             if not session:
-                return JSONResponse(
-                    create_mcp_response(
-                        data.get("id"),
-                        error={"code": -32000, "message": "Invalid session ID"}
-                    ),
-                    status_code=400
+                # Session expired or invalid - recreate it transparently
+                logger.warning(f"Session {mcp_session_id} expired or not found, recreating for project {project_slug}")
+                new_session_id = session_manager.create_session(
+                    project_slug=project_slug,
+                    api_key=api_key or "",
+                    base_url=base_url or DEFAULT_BASE_URL,
+                    domain=domain or "",
+                    metadata=metadata or ""
                 )
+                mcp_session_id = new_session_id
+                session = session_manager.get_session(mcp_session_id)
             
             # Use session defaults
             session_defaults = {

--- a/biel_mcp_server.py
+++ b/biel_mcp_server.py
@@ -618,18 +618,28 @@ async def streamable_http_endpoint_v2(
             
             # Validate session - auto-recreate if expired
             session = session_manager.get_session(mcp_session_id)
+            session_recreated = False
             if not session:
-                # Session expired or invalid - recreate it transparently
-                logger.warning(f"Session {mcp_session_id} expired or not found, recreating for project {project_slug}")
-                new_session_id = session_manager.create_session(
+                if not project_slug:
+                    return JSONResponse(
+                        create_mcp_response(
+                            data.get("id"),
+                            error={"code": -32000, "message": "Invalid session ID"}
+                        ),
+                        status_code=400
+                    )
+                logger.warning(
+                    f"Session {mcp_session_id[:8]}... expired or not found, recreating for project {project_slug}"
+                )
+                mcp_session_id = session_manager.create_session(
                     project_slug=project_slug,
                     api_key=api_key or "",
                     base_url=base_url or DEFAULT_BASE_URL,
                     domain=domain or "",
                     metadata=metadata or ""
                 )
-                mcp_session_id = new_session_id
                 session = session_manager.get_session(mcp_session_id)
+                session_recreated = True
             
             # Use session defaults
             session_defaults = {
@@ -644,7 +654,8 @@ async def streamable_http_endpoint_v2(
             
             # Handle the request
             mcp_response = await handle_mcp_request(data, session_defaults, mcp_session_id)
-            return JSONResponse(mcp_response)
+            response_headers = {"MCP-Session-Id": mcp_session_id} if session_recreated else None
+            return JSONResponse(mcp_response, headers=response_headers)
             
         except json.JSONDecodeError:
             return JSONResponse(


### PR DESCRIPTION
## Summary
- Auto-recreate expired/invalid MCP sessions on the v2 streamable HTTP endpoint instead of returning a `-32000 Invalid session ID` error.
- Reuses the request's `project_slug`, `api_key`, `base_url`, `domain`, and `metadata` to rebuild the session transparently, so clients don't have to re-handshake when the session TTL elapses.

## Test plan
- [ ] Send a request with a `Mcp-Session-Id` that no longer exists in the session manager and confirm the request is processed (warning logged, new session id used).
- [ ] Confirm valid sessions still work unchanged.
- [ ] Confirm session defaults from the recreated session are applied to the request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session resilience: The application now automatically recovers from expired or missing sessions by recreating them, ensuring uninterrupted operation instead of returning errors to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->